### PR TITLE
fix(docs): Broken typesetting

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Home to my personal configuration files.
 
 - [Nix] as package manager.
 - [Home Manager][] to take care of my home directory on [NixOS][] and non-NixOS.
-- [VSCodium](https://vscodium.com/) and [https://www.gnu.org/software/emacs/](GNU Emacs) with [https://github.com/hlissner/doom-emacs](Doom Emacs). 
+- [VSCodium](https://vscodium.com/) and (GNU Emacs)[https://www.gnu.org/software/emacs/] with (Doom Emacs)[https://github.com/hlissner/doom-emacs]. 
 
 ## Repository structure
 


### PR DESCRIPTION
Some links were typeset wrongly.
In fact, this is the correct typesetting for putting links in a Markdown file:
`[Title](https://example.net)`